### PR TITLE
updated to new JSON body format and fixed property error

### DIFF
--- a/entities/TestConfiguration.js
+++ b/entities/TestConfiguration.js
@@ -68,7 +68,7 @@ class TestConfiguration {
             assertionType, targetValue, actualValue, comparisonType, property, success,
           });
           break;
-        case 'jsonBody':	
+        case 'body':	
             targetValue = assertion.target || null;
             property = assertion.property[0] !== '$' ? `$.${assertion.property}` : assertion.property;
             comparisonType = assertion.comparison;

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ exports.handler = async (event) => {
   const body = JSON.parse(event.Records[0].body);
   const currRegion = event.Records[0].awsRegion;
   const { test } = JSON.parse(body.Message);
-
   console.log(`...starting test runner in ${currRegion}...`);
   console.log('SHAPE OF TEST ---> ', test);
 


### PR DESCRIPTION
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>

This PR: 
- updates comparison type to accept camel case
- updates assertion type to accept camel case
- fix bug when `property` is an empty string. In this case, the whole response body will be an `actualValue`.  The test result `property` value will be in that case set to `null`;
- If `actualValue` is an array or object the value will be stringified and only the first 300 characters will be assigned to `actualValue`. This is in case the object or array is very large. 
- The `actualValue` will look as follow:
```javascript
    actualValue: 'First 300 char:[{"_id":"62aa25c9899c9ef1522baaff","title":"Test board #2","createdAt":"2022-06-15T18:32:41.146Z","updatedAt":"2022-06-29T02:47:29.649Z"},{"_id":"62c1db3c8d3da8fb07b55e1f","title":"Test board #3","cre...',
``` 

After those changes, the Test Runner should accept the new test JSON format, where each assertion is stored as an array of objects. The case filters assertions by `type` property: 
```json
{
	"test": {
		"title": "New UI test",
		"locations": [
				"us-east-1",
				"us-west-1",
				"ca-central-1",
				"eu-north-1"
		],
		"minutesBetweenRuns": "1",
		"type": "API",
		"httpRequest": {
			"method": "GET",
			"url": "https://trellific.corkboard.dev/api/boards",
			"headers": {},
			"body": {},
			"assertions": [
			{
			"id": "c90ff75f-c971-40c7-9e34-5e5ae109e877",
			"type": "responseTime",
			"property": "",
			"comparison": "lessThan",
			"target": "500"
			},
			{
			"id": "33cabdf6-97d7-41b6-bc1c-37e701162405",
			"type": "statusCode",
			"property": "",
			"comparison": "equalTo",
			"target": "200"
			},
			{
			"id": "33cabdf6-97d7-41b6-bc1c-37e701162405",
			"type": "header",
			"property": "access-control-allow-origin",
			"comparison": "equalTo",
			"target": "*"
			},
			{
			"id": "33cabdf6-97d7-41b6-bc1c-37e7011624we",
			"type": "jsonBody",
			"property": "",
			"comparison": "contains",
			"target": "_id"
			}
		]
		}
	}
}
```