### PR TITLE
Accept null property

### DIFF
--- a/entities/TestConfiguration.js
+++ b/entities/TestConfiguration.js
@@ -70,7 +70,7 @@ class TestConfiguration {
           break;
         case 'body':	
             targetValue = assertion.target || null;
-            property = assertion.property[0] !== '$' ? `$.${assertion.property}` : assertion.property;
+						property = helpers.formatProperty(assertion.property); 
             comparisonType = assertion.comparison;
             actualValue = null;
 
@@ -83,9 +83,10 @@ class TestConfiguration {
             }
 
             if (typeof actualValue === 'object' || Array.isArray(actualValue)) {
-              actualValue = `First 300 char:${JSON.stringify(actualValue).slice(0, 200)}...`;
-              property = null; 
+              actualValue = actualValue;
+              property = property === '$.' ? null : property; 
             }
+
             results.push({
               assertionType, targetValue, actualValue, comparisonType, property, success,
             });

--- a/entities/TestConfiguration.js
+++ b/entities/TestConfiguration.js
@@ -70,7 +70,7 @@ class TestConfiguration {
           break;
         case 'body':	
             targetValue = assertion.target || null;
-						property = helpers.formatProperty(assertion.property); 
+            property = helpers.formatProperty(assertion.property); 
             comparisonType = assertion.comparison;
             actualValue = null;
 

--- a/entities/utils/helpers.js
+++ b/entities/utils/helpers.js
@@ -49,6 +49,14 @@ const getValue = (responseBody, property) => {
 
 const isObjectEmpty = (obj) => Object.keys(obj).length === 0;
 
+const formatProperty = (property) => {
+	if (property === null) {
+    return '$.'
+	} else {
+    return assertion.property[0] !== '$' ? `$.${assertion.property}` : assertion.property;
+	}
+}; 
+
 module.exports = {
   containsKeysOrVals,
   hasKeys,

--- a/entities/utils/helpers.js
+++ b/entities/utils/helpers.js
@@ -50,11 +50,11 @@ const getValue = (responseBody, property) => {
 const isObjectEmpty = (obj) => Object.keys(obj).length === 0;
 
 const formatProperty = (property) => {
-	if (property === null) {
+  if (property === null) {
     return '$.'
-	} else {
+  } else {
     return assertion.property[0] !== '$' ? `$.${assertion.property}` : assertion.property;
-	}
+  }
 }; 
 
 module.exports = {


### PR DESCRIPTION
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>

This PR: 
- updates the case for body assertion to accept `null` as a property. Before it only accepted strings but it needed to be changed because the Run Now CRUD endpoint forms JSON body for a single run directly from the data in the DB. If there was no input for that property DB stores the value as `null`. To avoid coercing an empty string to null in the CRUD, we handle `null` value in the Test Runner directly with a simple if else statement. 
- fixes the indentation   