### PR TITLE
changing 'header' to 'headers'

### DIFF
--- a/entities/TestConfiguration.js
+++ b/entities/TestConfiguration.js
@@ -54,11 +54,11 @@ class TestConfiguration {
             assertionType, targetValue, actualValue, comparisonType, property, success,
           });
           break;
-        case 'header':
+        case 'headers':
           responseHeaders = response.headers;
           comparisonType = assertion.comparison;
           targetValue = assertion.target;
-          property = assertion.property; 
+          property = assertion.property;
 
           success = TestConfiguration
             .checkHeaders(assertion, responseHeaders, comparisonType);
@@ -68,28 +68,28 @@ class TestConfiguration {
             assertionType, targetValue, actualValue, comparisonType, property, success,
           });
           break;
-        case 'body':	
-            targetValue = assertion.target || null;
-            property = helpers.formatProperty(assertion.property); 
-            comparisonType = assertion.comparison;
-            actualValue = null;
+        case 'body':
+          targetValue = assertion.target || null;
+          property = helpers.formatProperty(assertion.property);
+          comparisonType = assertion.comparison;
+          actualValue = null;
 
-            if ((!response.data) || (!Array.isArray(response.data) && typeof response.data !== 'object')) {
-              success = false;
-            } else {
-              const responseBody = response.data;
-              actualValue = property != "$." ? helpers.getValue(responseBody, property) : responseBody;
-              success = TestConfiguration.checkJsonBody(targetValue, actualValue, comparisonType);
-            }
+          if ((!response.data) || (!Array.isArray(response.data) && typeof response.data !== 'object')) {
+            success = false;
+          } else {
+            const responseBody = response.data;
+            actualValue = property !== '$.' ? helpers.getValue(responseBody, property) : responseBody;
+            success = TestConfiguration.checkJsonBody(targetValue, actualValue, comparisonType);
+          }
 
-            if (typeof actualValue === 'object' || Array.isArray(actualValue)) {
-              actualValue = actualValue;
-              property = property === '$.' ? null : property; 
-            }
+          if (typeof actualValue === 'object' || Array.isArray(actualValue)) {
+            actualValue = actualValue;
+            property = property === '$.' ? null : property;
+          }
 
-            results.push({
-              assertionType, targetValue, actualValue, comparisonType, property, success,
-            });
+          results.push({
+            assertionType, targetValue, actualValue, comparisonType, property, success,
+          });
 
           break;
         default:


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>

For a test that includes `headers` as an assertion type, the front-end sends the following payload (note the assertion type is "assertions"):

![Screen Shot 2022-07-30 at 1 20 37 PM](https://user-images.githubusercontent.com/72320460/181951701-4ef55109-c762-467f-af3f-2102d797348c.jpg)

because test-runner is currently expecting `header` (singular), the test runner throws an error.

2022-07-30T19:19:01.661Z	a955a9a3-8a0a-5e8c-8152-f2fc0c535b8d	INFO	SHAPE OF RESULTS ------> 
```
[
  {
    assertionType: 'headers',
    targetValue: undefined,
    actualValue: null,
    success: null,
    error: 'Unrecognized assertion type'
  }
]
```


