### PR TITLE
update header assertion to use the singular

### DIFF
--- a/entities/TestConfiguration.js
+++ b/entities/TestConfiguration.js
@@ -54,7 +54,7 @@ class TestConfiguration {
             assertionType, targetValue, actualValue, comparisonType, property, success,
           });
           break;
-        case 'headers':
+        case 'header':
           responseHeaders = response.headers;
           comparisonType = assertion.comparison;
           targetValue = assertion.target;


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

This PR updates test runner to match the test config type value sent by the frontend (i.e. "header" rather than "headers") 

# Validation
Ran `npm run locally` with updated `event.json` from https://github.com/No-Name-temporary/test-runner/pull/13 and saw this response: 

```
SHAPE OF RESULTS ------> [
  {
    assertionType: 'responseTime',
    targetValue: '600',
    actualValue: 159,
    comparisonType: 'lessThan',
    property: null,
    success: true
  },
  {
    assertionType: 'statusCode',
    targetValue: '200',
    actualValue: 200,
    comparisonType: 'equalTo',
    property: null,
    success: true
  },
  {
    assertionType: 'header',
    targetValue: 'close',
    actualValue: 'close',
    comparisonType: 'equalTo',
    property: 'connection',
    success: true
  },
  {
    assertionType: 'body',
    targetValue: 'end2end-prototype',
    actualValue: 'end2end-prototype',
    comparisonType: 'equalTo',
    property: '$[0].title',
    success: true
  }
]
```