### PR TITLE
fix type issue for equals assertions

### DIFF
--- a/entities/TestConfiguration.js
+++ b/entities/TestConfiguration.js
@@ -183,10 +183,10 @@ class TestConfiguration {
         result = actualValue > targetValue;
         break;
       case 'notEqualTo':
-        result = actualValue !== targetValue;
+        result = String(actualValue) !== String(targetValue);
         break;
       case 'equalTo':
-        result = actualValue === targetValue;
+        result = String(actualValue) === String(targetValue);
         break;
       case 'contains':
         if (typeof actualValue === 'object' && actualValue !== null) {


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

Previously, non string equals/not equals comparisons were not working as expected, e.g.: 
<img width="1298" alt="Screen Shot 2022-08-10 at 9 51 27 PM" src="https://user-images.githubusercontent.com/30358327/184066683-c9b36abb-0374-4720-89f6-76fafc2d18c3.png">

This is due to all target assertion values being string type, while the actual value may be a non string type. The short term fix implemented here is to coerce all values to a string type before an equals / not equals comparison. A better fix for future work will be to either infer and cast to the appropriate type or include the data type as part of the assertion.

# Validation
Ran all unit tests and `npm run locally`
